### PR TITLE
Add AWS SDK instrumentation integration tests for SQS, SNS and S3

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,6 +1,10 @@
 <Project>
   <Import Project="..\Directory.Packages.props" />
   <ItemGroup>
+    <PackageVersion Include="Amazon.SQS" Version="0.33.0" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.307.31" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.301.37" />
+    <PackageVersion Include="AWSSDK.SQS" Version="3.7.301.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.302" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.13.5" />

--- a/test/IntegrationTests/AWSCollection.cs
+++ b/test/IntegrationTests/AWSCollection.cs
@@ -16,9 +16,9 @@ public class AWSCollection : ICollectionFixture<AWSFixture>
 
 public class AWSFixture : IAsyncLifetime
 {
-    private const int DynamoDBLocalPort = 8000;
+    private const int LocalHostPort = 4566;
 
-    private static readonly string AWSDynamoDBLocalImage = "amazon/dynamodb-local";
+    private static readonly string AWSLocalImage = "localstack/localstack";
     // ReadImageFrom("aws.Dockerfile");
 
     private IContainer? _container;
@@ -45,12 +45,14 @@ public class AWSFixture : IAsyncLifetime
 
     private static async Task<IContainer> LaunchAWSDynamoDBContainerAsync(int port)
     {
-        var containerName = string.Format("aws-dynamodb-local-storage{0}", port);
+        var containerName = string.Format("aws-localstack{0}", port);
+
         var containersBuilder = new ContainerBuilder()
-            .WithImage(AWSDynamoDBLocalImage)
+            .WithImage(AWSLocalImage)
             .WithName(containerName)
-            .WithPortBinding(DynamoDBLocalPort, DynamoDBLocalPort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(DynamoDBLocalPort));
+            .WithPortBinding(LocalHostPort, LocalHostPort)
+            .WithPortBinding(4510, 4559)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(LocalHostPort));
 
         var container = containersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -134,6 +134,7 @@ public abstract class TestHelper
 
         // get path to test application that the profiler will attach to
         var testApplicationPath = EnvironmentHelper.GetTestApplicationPath(testSettings.PackageVersion, testSettings.Framework, startupMode);
+        testApplicationPath = "/Users/yiranwan/workplace/biroj_poc/opentelemetry-dotnet-instrumentation/test/test-applications/integrations/bin/TestApplication.AWS/Debug/net8.0/TestApplication.AWS.dll";
         if (!File.Exists(testApplicationPath))
         {
             throw new Exception($"application not found: {testApplicationPath}");

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -134,7 +134,6 @@ public abstract class TestHelper
 
         // get path to test application that the profiler will attach to
         var testApplicationPath = EnvironmentHelper.GetTestApplicationPath(testSettings.PackageVersion, testSettings.Framework, startupMode);
-        testApplicationPath = "/Users/yiranwan/workplace/biroj_poc/opentelemetry-dotnet-instrumentation/test/test-applications/integrations/bin/TestApplication.AWS/Debug/net8.0/TestApplication.AWS.dll";
         if (!File.Exists(testApplicationPath))
         {
             throw new Exception($"application not found: {testApplicationPath}");

--- a/test/test-applications/integrations/TestApplication.AWS/Program.cs
+++ b/test/test-applications/integrations/TestApplication.AWS/Program.cs
@@ -3,6 +3,9 @@
 
 using Amazon.DynamoDBv2;
 using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
 using TestApplication.Shared;
 
 namespace TestApplication.AWS;
@@ -13,21 +16,69 @@ public static class Program
     {
         ConsoleHelper.WriteSplashScreen(args);
         string tableName = "SampleData";
-        var clientConfig = new AmazonDynamoDBConfig { ServiceURL = "http://localhost:" + GetDDBServicePort(args) };
-        var amazonDynamoDb = new AmazonDynamoDBClient(new BasicAWSCredentials("testId", "testKey"), clientConfig);
+        var clientConfig = new AmazonDynamoDBConfig { ServiceURL = "http://localhost:" + GetAWSServicePort(args) };
+        var amazonDynamoDb = new AmazonDynamoDBClient(clientConfig);
         var ddbOperation = new DDBOperation(amazonDynamoDb, tableName);
         await ddbOperation.CreateTable();
         string id = await ddbOperation.InsertRow();
         await ddbOperation.SelectRow(id);
+
+        // For SQS
+        string queueName = "SampleQueue";
+        var sqs_clientConfig = new AmazonSQSConfig { ServiceURL = "http://localhost:" + GetAWSServicePort(args) };
+        var sqs = new AmazonSQSClient(sqs_clientConfig);
+        var sqsOperation = new SQSOperation(sqs, queueName);
+        // Create
+        string queueUrl = await sqsOperation.CreateQueue();
+        // Read
+        await sqsOperation.ListQueues();
+        await sqsOperation.GetQueueArn(queueUrl);
+        // Update
+        await sqsOperation.UpdateQueue(queueUrl);
+        // Delete
+        await sqsOperation.DeleteQueue(queueUrl);
+
+        // For SNS
+        string topicName = "SampleTopic";
+        var sns_clientConfig = new AmazonSimpleNotificationServiceConfig { ServiceURL = "http://localhost:" + GetAWSServicePort(args) };
+        var sns = new AmazonSimpleNotificationServiceClient(sns_clientConfig);
+        var snsOperation = new SNSOperation(sns, topicName);
+        // Create
+        string topicArn = await snsOperation.CreateTopic();
+        // Read
+        await snsOperation.ListTopics();
+        // Update
+        await snsOperation.SendMessage(topicArn);
+        // Delete
+        await snsOperation.DeleteTopic(topicArn);
+
+        // For S3
+        string bucketName = "samplebucket";
+        var s3_clientConfig = new AmazonS3Config
+        {
+            ServiceURL = "http://localhost:" + GetAWSServicePort(args),
+            ForcePathStyle = true
+        };
+        var s3 = new AmazonS3Client(s3_clientConfig);
+        var s3Operation = new S3Operation(s3, bucketName);
+        // Create
+        await s3Operation.CreateBucket();
+        // Read
+        await s3Operation.GetBucketVersioning();
+        // Update
+        await s3Operation.PutObject();
+        // Delete
+        await s3Operation.DeleteObject();
+        await s3Operation.DeleteBucket();
     }
 
-    private static string GetDDBServicePort(string[] args)
+    private static string GetAWSServicePort(string[] args)
     {
         if (args.Length == 1)
         {
             return args[0];
         }
 
-        return "8000";
+        return "4566";
     }
 }

--- a/test/test-applications/integrations/TestApplication.AWS/S3Operation.cs
+++ b/test/test-applications/integrations/TestApplication.AWS/S3Operation.cs
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace TestApplication.AWS;
+
+public class S3Operation
+{
+    private readonly IAmazonS3 _s3;
+    private readonly string _bucketName;
+
+    public S3Operation(IAmazonS3 s3, string bucketName)
+    {
+        _s3 = s3;
+        _bucketName = bucketName;
+    }
+
+    public async Task CreateBucket()
+    {
+        var putBucketRequest = new PutBucketRequest
+        {
+            BucketName = _bucketName,
+            UseClientRegion = true
+        };
+
+        await _s3.PutBucketAsync(putBucketRequest);
+    }
+
+    public async Task<S3BucketVersioningConfig> GetBucketVersioning()
+    {
+        GetBucketVersioningResponse response = await _s3.GetBucketVersioningAsync(_bucketName);
+        return response.VersioningConfig;
+    }
+
+    public async Task PutObject()
+    {
+        var putRequest = new PutObjectRequest
+        {
+            BucketName = _bucketName,
+            Key = "sample_key",
+            ContentBody = "sample_text"
+        };
+        await _s3.PutObjectAsync(putRequest);
+    }
+
+    public async Task DeleteObject()
+    {
+        var deleteObjectRequest = new DeleteObjectRequest
+        {
+            BucketName = _bucketName,
+            Key = "sample_key"
+        };
+        await _s3.DeleteObjectAsync(deleteObjectRequest);
+    }
+
+    public async Task DeleteBucket()
+    {
+        await _s3.DeleteBucketAsync(_bucketName);
+    }
+}

--- a/test/test-applications/integrations/TestApplication.AWS/SNSOperation.cs
+++ b/test/test-applications/integrations/TestApplication.AWS/SNSOperation.cs
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+
+namespace TestApplication.AWS;
+
+public class SNSOperation
+{
+    private readonly IAmazonSimpleNotificationService _sns;
+    private readonly string _topicName;
+
+    public SNSOperation(IAmazonSimpleNotificationService sns, string topicName)
+    {
+        _sns = sns;
+        _topicName = topicName;
+    }
+
+    public async Task<string> CreateTopic()
+    {
+        var createRequest = new CreateTopicRequest(_topicName);
+        CreateTopicResponse responseCreate = await _sns.CreateTopicAsync(createRequest);
+        return responseCreate.TopicArn;
+    }
+
+    public async Task<List<Topic>> ListTopics()
+    {
+        ListTopicsResponse responseList = await _sns.ListTopicsAsync();
+        return responseList.Topics;
+    }
+
+    public async Task SendMessage(string topicArn)
+    {
+        var publishRequest = new PublishRequest
+        {
+            Message = "message",
+            TopicArn = topicArn
+        };
+        await _sns.PublishAsync(publishRequest);
+    }
+
+    public async Task DeleteTopic(string topicArn)
+    {
+        await _sns.DeleteTopicAsync(topicArn);
+    }
+}

--- a/test/test-applications/integrations/TestApplication.AWS/SQSOperation.cs
+++ b/test/test-applications/integrations/TestApplication.AWS/SQSOperation.cs
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+
+namespace TestApplication.AWS;
+
+public class SQSOperation
+{
+    private readonly IAmazonSQS _sqs;
+    private readonly string _queueName;
+
+    public SQSOperation(IAmazonSQS sqs, string queueName)
+    {
+        _sqs = sqs;
+        _queueName = queueName;
+    }
+
+    public async Task<string> CreateQueue()
+    {
+        var createRequest = new CreateQueueRequest(_queueName);
+        CreateQueueResponse responseCreate = await _sqs.CreateQueueAsync(createRequest);
+        return responseCreate.QueueUrl;
+    }
+
+    public async Task<List<string>> ListQueues()
+    {
+        ListQueuesResponse responseList = await _sqs.ListQueuesAsync(string.Empty);
+        return responseList.QueueUrls;
+    }
+
+    public async Task UpdateQueue(string queueUrl)
+    {
+        await _sqs.SetQueueAttributesAsync(
+            queueUrl,
+            new Dictionary<string, string> { { "MessageRetentionPeriod", "600" } });
+    }
+
+    public async Task DeleteQueue(string queueUrl)
+    {
+        await _sqs.DeleteQueueAsync(queueUrl);
+    }
+
+    public async Task<string> GetQueueArn(string queueUrl)
+    {
+        GetQueueAttributesResponse responseGetAtt =
+            await _sqs.GetQueueAttributesAsync(
+                queueUrl,
+                new List<string> { QueueAttributeName.QueueArn });
+        return responseGetAtt.QueueARN;
+    }
+}

--- a/test/test-applications/integrations/TestApplication.AWS/TestApplication.AWS.csproj
+++ b/test/test-applications/integrations/TestApplication.AWS/TestApplication.AWS.csproj
@@ -2,5 +2,8 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" VersionOverride="$(LibraryVersion)" />
+    <PackageReference Include="AWSSDK.S3" VersionOverride="$(LibraryVersion)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" VersionOverride="$(LibraryVersion)" />
+    <PackageReference Include="AWSSDK.SQS" VersionOverride="$(LibraryVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

Extend AWS SDK instrumentation integration tests for SQS, SNS and S3 CRUD operations

Fixes #

## What

Extend AWS SDK instrumentation integration tests for SQS, SNS and S3 CRUD operations

## Tests

Run `dotnet test --filter "IntegrationTests.AWS"`

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
